### PR TITLE
optimize vector lift instance

### DIFF
--- a/src/Data/Vector/Lift.hs
+++ b/src/Data/Vector/Lift.hs
@@ -1,9 +1,22 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Data.Vector.Lift where
 
-import Data.Vector.Storable
+import qualified Data.Vector.Storable as V
+import Data.Word
+import Foreign.Storable
+import GHC.ForeignPtr
+import GHC.Ptr
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
+import System.IO.Unsafe
 
-instance (Storable a, Lift a) => Lift (Vector a) where
-    lift = appE (varE 'fromList) . lift . toList
+instance (Storable a) => Lift (V.Vector a) where
+  lift v = [|
+    unsafePerformIO $ do
+      ptr <- newForeignPtr_ (Ptr $(bytes))
+      return $ V.unsafeFromForeignPtr ptr offset length
+    |]
+    where
+      bytes = litE $ StringPrimL $ V.toList $ (V.unsafeCast v :: V.Vector Word8)
+      offset = 0 :: Int
+      length = V.length v

--- a/src/Data/Vector/Lift.hs
+++ b/src/Data/Vector/Lift.hs
@@ -10,13 +10,13 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 import System.IO.Unsafe
 
-instance (Storable a) => Lift (V.Vector a) where
-  lift v = [|
-    unsafePerformIO $ do
-      ptr <- newForeignPtr_ (Ptr $(bytes))
-      return $ V.unsafeFromForeignPtr ptr offset length
-    |]
-    where
-      bytes = litE $ StringPrimL $ V.toList $ (V.unsafeCast v :: V.Vector Word8)
-      offset = 0 :: Int
-      length = V.length v
+vecLift :: (Storable a) => V.Vector a -> TExpQ (V.Vector a)
+vecLift v = unsafeTExpCoerce [|
+  unsafePerformIO $ do
+    ptr <- newForeignPtr_ (Ptr $(bytes))
+    return $ V.unsafeFromForeignPtr ptr offset length
+  |]
+  where
+    bytes = litE $ StringPrimL $ V.toList $ (V.unsafeCast v :: V.Vector Word8)
+    offset = 0 :: Int
+    length = V.length v

--- a/src/Quotes/Base16.hs
+++ b/src/Quotes/Base16.hs
@@ -12,4 +12,4 @@ base16 :: (Storable a, Lift a) => String -> TExpQ (V.Vector a)
 base16 s =
   case parseBase16 s of
     Left err -> fail (show err)
-    Right vec -> [|| vec ||]
+    Right vec -> vecLift vec

--- a/src/Quotes/Base64.hs
+++ b/src/Quotes/Base64.hs
@@ -12,4 +12,4 @@ base64 :: (Storable a, Lift a) => String -> TExpQ (V.Vector a)
 base64 s =
   case parseBase64 s of
     Left err -> fail (show err)
-    Right vec -> [|| vec ||]
+    Right vec -> vecLift vec

--- a/src/Quotes/DataURL.hs
+++ b/src/Quotes/DataURL.hs
@@ -12,4 +12,4 @@ dataURL :: (Storable a, Lift a) => String -> TExpQ (V.Vector a)
 dataURL s =
   case parseDataURL s of
     Left err -> fail (show err)
-    Right vec -> [|| vec ||]
+    Right vec -> vecLift vec

--- a/src/Quotes/Slices.hs
+++ b/src/Quotes/Slices.hs
@@ -8,4 +8,4 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 
 mkSlice :: (Storable a, Lift a) => Int -> Int -> V.Vector a -> TExpQ (V.Vector a)
-mkSlice i n vec = let nVec = V.slice i n vec in vecLift nVec
+mkSlice i n = vecLift . V.slice i n

--- a/src/Quotes/Slices.hs
+++ b/src/Quotes/Slices.hs
@@ -8,4 +8,4 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 
 mkSlice :: (Storable a, Lift a) => Int -> Int -> V.Vector a -> TExpQ (V.Vector a)
-mkSlice i n vec = let nVec = V.slice i n vec in [|| nVec ||]
+mkSlice i n vec = let nVec = V.slice i n vec in vecLift nVec


### PR DESCRIPTION
Что-то похожее написано в `th-lift-instances` для `ByteString`. Без понятия, насколько это вообще делается без `unsafePerformIO` и нет ли здесь какого-нибудь неопределённого поведения)